### PR TITLE
Added FriendlyError class, some lexer errors.

### DIFF
--- a/lib/src/error.dart
+++ b/lib/src/error.dart
@@ -1,49 +1,38 @@
 import 'package:source_span/source_span.dart';
 
 /// A pretty error format for the project.
-abstract class FriendlyError extends Error {
-  /// the line number of the error.
-  String get line;
-
-  /// the sourceFile (if availible) or None.
-  String get sourceFile;
-
-  /// the text span where the error is located.
-  String get sourceLine;
+abstract class SourceError extends Error {
+  /// The source span where the error occurred.
+  SourceSpan get source;
 
   /// A friendly, Actionable error message.
-  String get errorMessage;
+  String get message;
 
   @override
   String toString() {
-    return '\n---- PARSE ERROR ----------- $sourceFile\n' +
+    final line = span.start.line.toString();
+    return '\n---- PARSE ERROR ----------- ${span.sourceUrl?.path ?? 'No File'}\n' +
         '\n' +
         'There was a problem while parsing the following line:\n' +
-        '$line| $sourceLine\n' +
-        '${' ' * (line.length + sourceLine.length + 1)}^\n' +
-        '$errorMessage\n';
+        '$line| ${source.text}\n' +
+        '${' ' * (line.length + source.text.length + 1)}^\n' +
+        '$message\n';
   }
 }
 
 /// Simple errors which can occur during lexical analysis.
-class LexerError extends FriendlyError {
+class LexerError extends SourceError {
   /// The source span where the error was encountered, from column 0.
-  final SourceSpan span;
+  final SourceSpan source;
 
   /// Additional lexer context into the failure.
   final LexerErrorKind kind;
 
   /// Used to signal possible malformed html to the parser.
-  LexerError(this.span, this.kind);
+  LexerError(this.source, this.kind);
 
   @override
-  String get sourceFile => span.sourceUrl?.path ?? 'No File';
-  @override
-  String get sourceLine => span.text;
-  @override
-  String get line => '${span.start.line}';
-  @override
-  String get errorMessage {
+  String get message {
     switch (kind) {
       case LexerErrorKind.misMatchedClose:
         return 'I found an unnecessary closing tag.';

--- a/lib/src/error.dart
+++ b/lib/src/error.dart
@@ -10,8 +10,8 @@ abstract class SourceError extends Error {
 
   @override
   String toString() {
-    final line = span.start.line.toString();
-    return '\n---- PARSE ERROR ----------- ${span.sourceUrl?.path ?? 'No File'}\n' +
+    final line = source.start.line.toString();
+    return '\n---- PARSE ERROR ----------- ${source.sourceUrl?.path ?? 'No File'}\n' +
         '\n' +
         'There was a problem while parsing the following line:\n' +
         '$line| ${source.text}\n' +

--- a/lib/src/error.dart
+++ b/lib/src/error.dart
@@ -46,11 +46,11 @@ class LexerError extends FriendlyError {
   String get errorMessage {
     switch (kind) {
       case LexerErrorKind.misMatchedClose:
-        return 'I found an unecessary closing tag.';
+        return 'I found an unnecessary closing tag.';
       case LexerErrorKind.misMatchedOpen:
-        return 'I found an unecessary opening tag.';
+        return 'I found an unnecessary opening tag.';
       default:
-        return "This shouldn't happen";
+        return "This shouldn't happen.";
     }
   }
 }

--- a/lib/src/lexer.dart
+++ b/lib/src/lexer.dart
@@ -2,6 +2,8 @@ import 'package:charcode/charcode.dart';
 import 'package:source_span/source_span.dart';
 import 'package:string_scanner/string_scanner.dart';
 
+import 'lexer_error.dart';
+
 /// A parsed HTML token.
 abstract class HtmlToken {
   /// Where the token is from.
@@ -114,9 +116,10 @@ enum HtmlLexerState {
   scanningClosingTagName,
 }
 
+
 /// Produces [HtmlToken]s from a [String].
 class HtmlLexer {
-  final StringScanner _scanner;
+  final LineScanner _scanner;
 
   HtmlLexerState _state = HtmlLexerState.scanningText;
   int _sentinel = 0;
@@ -124,7 +127,7 @@ class HtmlLexer {
   /// Create a new [HtmlLexer] to lex [contents] from [sourceUrl].
   factory HtmlLexer(String contents, {/*String|Uri*/ sourceUrl}) {
     return new HtmlLexer._fromScanner(
-        new StringScanner(contents, sourceUrl: sourceUrl));
+        new LineScanner(contents, sourceUrl: sourceUrl));
   }
 
   // An HtmlTokenizer wraps a StringScanner instance.
@@ -145,6 +148,24 @@ class HtmlLexer {
     );
     _sentinel = _scanner.position;
     return span;
+  }
+  // Creates a source span from the beginning of the line, with line info.
+  SourceSpan _errorContext() {
+    int start = _scanner.position - _scanner.column;
+    int stop = _scanner.position;
+    return new SourceSpan(
+      new SourceLocation(
+        start,
+        sourceUrl: _scanner.sourceUrl,
+        line: _scanner.line,
+      ),
+      new SourceLocation(
+        stop,
+        sourceUrl: _scanner.sourceUrl,
+        line: _scanner.line,
+      ),
+      _scanner.substring(start, stop)
+    );
   }
 
   SourceSpan _point([int offset = 0]) => new SourceLocation(
@@ -171,6 +192,9 @@ class HtmlLexer {
               _state = HtmlLexerState.scanningOpenTag;
               yield new HtmlTokenImpl.tagOpenStart(_point());
             }
+          } else if (_scanner.scanChar($gt)) {
+            throw new LexerError(_errorContext(),
+              LexerErrorKind.misMatchedClose);
           }
           break;
         case HtmlLexerState.scanningOpenTag:
@@ -178,6 +202,10 @@ class HtmlLexer {
             yield new HtmlTokenImpl.tagName(_span());
             yield new HtmlTokenImpl.tagOpenEnd(_point());
             _state = HtmlLexerState.scanningText;
+          } else if (_scanner.scanChar($lt)) {
+            throw new LexerError(
+              _errorContext(),
+              LexerErrorKind.misMatchedOpen);
           }
           break;
         case HtmlLexerState.scanningCloseTag:

--- a/lib/src/lexer.dart
+++ b/lib/src/lexer.dart
@@ -2,7 +2,7 @@ import 'package:charcode/charcode.dart';
 import 'package:source_span/source_span.dart';
 import 'package:string_scanner/string_scanner.dart';
 
-import 'lexer_error.dart';
+import 'error.dart';
 
 /// A parsed HTML token.
 abstract class HtmlToken {

--- a/lib/src/lexer.dart
+++ b/lib/src/lexer.dart
@@ -116,7 +116,6 @@ enum HtmlLexerState {
   scanningClosingTagName,
 }
 
-
 /// Produces [HtmlToken]s from a [String].
 class HtmlLexer {
   final LineScanner _scanner;
@@ -149,23 +148,23 @@ class HtmlLexer {
     _reset();
     return span;
   }
+
   // Creates a source span from the beginning of the line, with line info.
   SourceSpan _errorContext() {
     int start = _scanner.position - _scanner.column;
     int stop = _scanner.position;
     return new SourceSpan(
-      new SourceLocation(
-        start,
-        sourceUrl: _scanner.sourceUrl,
-        line: _scanner.line,
-      ),
-      new SourceLocation(
-        stop,
-        sourceUrl: _scanner.sourceUrl,
-        line: _scanner.line,
-      ),
-      _scanner.substring(start, stop)
-    );
+        new SourceLocation(
+          start,
+          sourceUrl: _scanner.sourceUrl,
+          line: _scanner.line,
+        ),
+        new SourceLocation(
+          stop,
+          sourceUrl: _scanner.sourceUrl,
+          line: _scanner.line,
+        ),
+        _scanner.substring(start, stop));
   }
 
   SourceSpan _point([int offset = 0]) {
@@ -201,8 +200,8 @@ class HtmlLexer {
               yield new HtmlTokenImpl.tagOpenStart(_point());
             }
           } else if (_scanner.scanChar($gt)) {
-            throw new LexerError(_errorContext(),
-              LexerErrorKind.misMatchedClose);
+            throw new LexerError(
+                _errorContext(), LexerErrorKind.misMatchedClose);
           }
           break;
         case HtmlLexerState.scanningOpenTag:
@@ -213,8 +212,7 @@ class HtmlLexer {
             _state = HtmlLexerState.scanningText;
           } else if (_scanner.scanChar($lt)) {
             throw new LexerError(
-              _errorContext(),
-              LexerErrorKind.misMatchedOpen);
+                _errorContext(), LexerErrorKind.misMatchedOpen);
           }
           break;
         case HtmlLexerState.scanningCloseTag:

--- a/lib/src/lexer.dart
+++ b/lib/src/lexer.dart
@@ -116,7 +116,6 @@ enum HtmlLexerState {
   scanningClosingTagName,
 }
 
-
 /// Produces [HtmlToken]s from a [String].
 class HtmlLexer {
   final LineScanner _scanner;
@@ -149,23 +148,23 @@ class HtmlLexer {
     _sentinel = _scanner.position;
     return span;
   }
+
   // Creates a source span from the beginning of the line, with line info.
   SourceSpan _errorContext() {
     int start = _scanner.position - _scanner.column;
     int stop = _scanner.position;
     return new SourceSpan(
-      new SourceLocation(
-        start,
-        sourceUrl: _scanner.sourceUrl,
-        line: _scanner.line,
-      ),
-      new SourceLocation(
-        stop,
-        sourceUrl: _scanner.sourceUrl,
-        line: _scanner.line,
-      ),
-      _scanner.substring(start, stop)
-    );
+        new SourceLocation(
+          start,
+          sourceUrl: _scanner.sourceUrl,
+          line: _scanner.line,
+        ),
+        new SourceLocation(
+          stop,
+          sourceUrl: _scanner.sourceUrl,
+          line: _scanner.line,
+        ),
+        _scanner.substring(start, stop));
   }
 
   SourceSpan _point([int offset = 0]) => new SourceLocation(
@@ -193,8 +192,8 @@ class HtmlLexer {
               yield new HtmlTokenImpl.tagOpenStart(_point());
             }
           } else if (_scanner.scanChar($gt)) {
-            throw new LexerError(_errorContext(),
-              LexerErrorKind.misMatchedClose);
+            throw new LexerError(
+                _errorContext(), LexerErrorKind.misMatchedClose);
           }
           break;
         case HtmlLexerState.scanningOpenTag:
@@ -204,8 +203,7 @@ class HtmlLexer {
             _state = HtmlLexerState.scanningText;
           } else if (_scanner.scanChar($lt)) {
             throw new LexerError(
-              _errorContext(),
-              LexerErrorKind.misMatchedOpen);
+                _errorContext(), LexerErrorKind.misMatchedOpen);
           }
           break;
         case HtmlLexerState.scanningCloseTag:

--- a/lib/src/lexer_error.dart
+++ b/lib/src/lexer_error.dart
@@ -1,0 +1,50 @@
+import 'package:source_span/source_span.dart';
+
+/// Simple errors which can occur during lexical analysis.
+class LexerError extends Error {
+  /// The source span where the error was encountered, from column 0.
+  final SourceSpan span;
+  /// Additional lexer context into the failure.
+  final LexerErrorKind kind;
+
+  /// Used to signal possible malformed html to the parser.
+  LexerError(this.span, this.kind);
+
+  /// Returns a string representation of the file path.
+  String get filePath => span.sourceUrl?.path ?? 'No File';
+
+  String _errorMessage() {
+    switch(kind) {
+      case LexerErrorKind.misMatchedClose:
+        return 'I found an unecessary closing tag.';
+      case LexerErrorKind.misMatchedOpen:
+        return 'I found an unecessary opening tag.';
+      default:
+        return "This shouldn't happen";
+    }
+  }
+  /// If the error can not be handled, use this nicely formatted message.
+  /// called a parsing error because people know what that is.
+  /// TODO: standard error formatting class?
+  @override
+  String toString() {
+    final index = span.start.line;
+    return '\n---- PARSE ERROR ----------- $filePath\n' +
+    '\n' +
+    'There was a problem while parsing the following line:\n' +
+    '$index| ${span.text}\n' +
+    '  ${' ' * index.toString().length}${' ' * (span.text.length - 1)}^\n' +
+    '${_errorMessage()}\n';
+  }
+}
+
+/// LexerErrorKind provides more specific context about the kind of error
+/// encountered.
+enum LexerErrorKind {
+  /// found an extra '<'
+  misMatchedOpen,
+  /// found an extra '>'
+  misMatchedClose,
+  /// found a character inside of a tag that doesn't belong
+  misMatchedTag,
+}

--- a/lib/src/lexer_error.dart
+++ b/lib/src/lexer_error.dart
@@ -4,6 +4,7 @@ import 'package:source_span/source_span.dart';
 class LexerError extends Error {
   /// The source span where the error was encountered, from column 0.
   final SourceSpan span;
+
   /// Additional lexer context into the failure.
   final LexerErrorKind kind;
 
@@ -14,7 +15,7 @@ class LexerError extends Error {
   String get filePath => span.sourceUrl?.path ?? 'No File';
 
   String _errorMessage() {
-    switch(kind) {
+    switch (kind) {
       case LexerErrorKind.misMatchedClose:
         return 'I found an unecessary closing tag.';
       case LexerErrorKind.misMatchedOpen:
@@ -23,6 +24,7 @@ class LexerError extends Error {
         return "This shouldn't happen";
     }
   }
+
   /// If the error can not be handled, use this nicely formatted message.
   /// called a parsing error because people know what that is.
   /// TODO: standard error formatting class?
@@ -30,11 +32,11 @@ class LexerError extends Error {
   String toString() {
     final index = span.start.line;
     return '\n---- PARSE ERROR ----------- $filePath\n' +
-    '\n' +
-    'There was a problem while parsing the following line:\n' +
-    '$index| ${span.text}\n' +
-    '  ${' ' * index.toString().length}${' ' * (span.text.length - 1)}^\n' +
-    '${_errorMessage()}\n';
+        '\n' +
+        'There was a problem while parsing the following line:\n' +
+        '$index| ${span.text}\n' +
+        '  ${' ' * index.toString().length}${' ' * (span.text.length - 1)}^\n' +
+        '${_errorMessage()}\n';
   }
 }
 
@@ -43,8 +45,10 @@ class LexerError extends Error {
 enum LexerErrorKind {
   /// found an extra '<'
   misMatchedOpen,
+
   /// found an extra '>'
   misMatchedClose,
+
   /// found a character inside of a tag that doesn't belong
   misMatchedTag,
 }

--- a/test/lexer_text.dart
+++ b/test/lexer_text.dart
@@ -17,11 +17,13 @@ void main() {
       ]);
     });
     test('it should throw basic missmatched tag errors', () {
-      final raw = '<h1>\n<p [baz]="foo"> This is some markup</p>\n<div>some mo</div></h1>>';
+      final raw =
+          '<h1>\n<p [baz]="foo"> This is some markup</p>\n<div>some mo</div></h1>>';
       final lexer = new HtmlLexer(raw);
-      expect(() => lexer.tokenize().toList(),
-        throwsA(predicate(
-          (e) => e is LexerError && e.kind == LexerErrorKind.misMatchedClose)));
+      expect(
+          () => lexer.tokenize().toList(),
+          throwsA(predicate((e) =>
+              e is LexerError && e.kind == LexerErrorKind.misMatchedClose)));
     });
   });
 }

--- a/test/lexer_text.dart
+++ b/test/lexer_text.dart
@@ -1,5 +1,5 @@
 import 'package:html_parser/src/lexer.dart';
-import 'package:html_parser/src/lexer_error.dart';
+import 'package:html_parser/src/error.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -46,7 +46,7 @@ void main() {
       ]);
     test('it should throw basic missmatched tag errors', () {
       final raw =
-          '<h1>\n<p [baz]="foo"> This is some markup</p>\n<div>some mo</div></h1>>';
+          '<h1>\n<p [baz]="foo"> This is markup</p>\n<div>some mo</div></h1>>';
       final lexer = new HtmlLexer(raw);
       expect(
           () => lexer.tokenize().toList(),

--- a/test/lexer_text.dart
+++ b/test/lexer_text.dart
@@ -1,4 +1,5 @@
 import 'package:html_parser/src/lexer.dart';
+import 'package:html_parser/src/lexer_error.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -14,6 +15,13 @@ void main() {
         HtmlTokenType.tagName,
         HtmlTokenType.tagCloseEnd,
       ]);
+    });
+    test('it should throw basic missmatched tag errors', () {
+      final raw = '<h1>\n<p [baz]="foo"> This is some markup</p>\n<div>some mo</div></h1>>';
+      final lexer = new HtmlLexer(raw);
+      expect(() => lexer.tokenize().toList(),
+        throwsA(predicate(
+          (e) => e is LexerError && e.kind == LexerErrorKind.misMatchedClose)));
     });
   });
 }

--- a/test/lexer_text.dart
+++ b/test/lexer_text.dart
@@ -45,11 +45,13 @@ void main() {
         HtmlTokenType.text, // "\n"
       ]);
     test('it should throw basic missmatched tag errors', () {
-      final raw = '<h1>\n<p [baz]="foo"> This is some markup</p>\n<div>some mo</div></h1>>';
+      final raw =
+          '<h1>\n<p [baz]="foo"> This is some markup</p>\n<div>some mo</div></h1>>';
       final lexer = new HtmlLexer(raw);
-      expect(() => lexer.tokenize().toList(),
-        throwsA(predicate(
-          (e) => e is LexerError && e.kind == LexerErrorKind.misMatchedClose)));
+      expect(
+          () => lexer.tokenize().toList(),
+          throwsA(predicate((e) =>
+              e is LexerError && e.kind == LexerErrorKind.misMatchedClose)));
     });
   });
 });

--- a/test/lexer_text.dart
+++ b/test/lexer_text.dart
@@ -1,5 +1,5 @@
 import 'package:html_parser/src/lexer.dart';
-import 'package:html_parser/src/lexer_error.dart';
+import 'package:html_parser/src/error.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -18,7 +18,7 @@ void main() {
     });
     test('it should throw basic missmatched tag errors', () {
       final raw =
-          '<h1>\n<p [baz]="foo"> This is some markup</p>\n<div>some mo</div></h1>>';
+          '<h1>\n<p [baz]="foo"> This is markup</p>\n<div>some mo</div></h1>>';
       final lexer = new HtmlLexer(raw);
       expect(
           () => lexer.tokenize().toList(),

--- a/test/lexer_text.dart
+++ b/test/lexer_text.dart
@@ -1,4 +1,5 @@
 import 'package:html_parser/src/lexer.dart';
+import 'package:html_parser/src/lexer_error.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -43,8 +44,15 @@ void main() {
         HtmlTokenType.tagCloseEnd, // "</"
         HtmlTokenType.text, // "\n"
       ]);
+    test('it should throw basic missmatched tag errors', () {
+      final raw = '<h1>\n<p [baz]="foo"> This is some markup</p>\n<div>some mo</div></h1>>';
+      final lexer = new HtmlLexer(raw);
+      expect(() => lexer.tokenize().toList(),
+        throwsA(predicate(
+          (e) => e is LexerError && e.kind == LexerErrorKind.misMatchedClose)));
     });
   });
+});
 }
 
 Iterable<HtmlTokenType> _toTypes(HtmlLexer htmlLexer) =>

--- a/test/lexer_text.dart
+++ b/test/lexer_text.dart
@@ -43,6 +43,7 @@ void main() {
         HtmlTokenType.tagCloseEnd, // "</"
         HtmlTokenType.text, // "\n"
       ]);
+    });
     test('it should throw basic missmatched tag errors', () {
       final raw =
           '<h1>\n<p [baz]="foo"> This is markup</p>\n<div>some mo</div></h1>>';
@@ -53,7 +54,6 @@ void main() {
               e is LexerError && e.kind == LexerErrorKind.misMatchedClose)));
     });
   });
-});
 }
 
 Iterable<HtmlTokenType> _toTypes(HtmlLexer htmlLexer) =>


### PR DESCRIPTION
Created an abstract class called FriendlyError (tm), which has a reusable template toString method.  Ideally, we could write very clear and concise error messages.  It has a single subclass currently called LexerError.  This gets thrown occurs when there is a double < or > like '<<div' or 'div>>'.  To support these error formats, I changed the implementation of the StringScanner to a LineScanner so we can have column information.

<img width="669" alt="screen shot 2016-09-30 at 6 03 11 pm" src="https://cloud.githubusercontent.com/assets/8975114/19011117/06e3ccd8-8742-11e6-991a-13dc87a63402.png">

also I wrote a test!
