### PR TITLE
Added initial set of supported tags, added utils for querying tag usage.

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -7,7 +7,7 @@ const List<String> unsupportedTags = const [
 ];
 
 /// Defines `void` HTML elements (no closing tag).
-Set<String> voidTags = new Set.from([
+final Set<String> voidTags = new Set.from([
   'area',
   'base',
   'basefont',
@@ -16,7 +16,7 @@ Set<String> voidTags = new Set.from([
   'col',
   'command',
   'embed',
-  //'frame', -- is this still a valid HTML5 tag?
+  'frame',
   'hr',
   'img',
   'input',
@@ -30,7 +30,7 @@ Set<String> voidTags = new Set.from([
 ]);
 
 /// Defines normal HTML elements (requires closing tags).
-Set<String> regularTags = new Set.from([
+final Set<String> regularTags = new Set.from([
   'a',
   'abbr',
   'address',
@@ -137,12 +137,6 @@ bool isWhitespace(int c) =>
 /// Whether [tagName] is a considered a `void` HTML element (no closing tag).
 bool isVoid(String tagName) => voidTags.contains(tagName.toLowerCase());
 
-/// Whether [tagName] is a know HTML element, or a web/angular component.
-bool isKnownTag(String tagName) {
-  final lowerName = tagName.toLowerCase();
-  return voidTags.contains(lowerName) || regularTags.contains(lowerName);
-}
-
 /// Retrieves all tags used in the tree starting with [element]
 ///
 /// When combined with isKnownTag, can produce an iterable of tag names
@@ -150,8 +144,8 @@ bool isKnownTag(String tagName) {
 ///
 /// # Example use
 ///     Element root = ...
-///     final nonNativeTags = usedTags(root).where((x) => !isKnownTag(x));
-///     
+///     final divs = usedTags(root).where((x) => x == 'div');
+///
 Iterable<String> usedTags(Element element) sync* {
   yield element.tagName;
   for (Element child in element.childNodes) {

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -143,19 +143,18 @@ bool isKnownTag(String tagName) {
   return voidTags.contains(lowerName) || regularTags.contains(lowerName);
 }
 
-/// Retrieves all tags which are not known as part of the HTML spec.
+/// Retrieves all tags used in the tree starting with [element]
 ///
-/// This can be used to identify cases where the developer forgot to include
-/// a component in directives.
-/// __example__:
-///     final xs = nonNativeTags(element);
-///     print(xs);
-///     // prints ["my-div", "foo-bar"]
-Iterable<String> nonNativeTags(Element element) sync* {
-  if (!isKnownTag(element.tagName)) {
-    yield element.tagName;
-  }
+/// When combined with isKnownTag, can produce an iterable of tag names
+/// which need to be found in Directives.
+///
+/// # Example use
+///     Element root = ...
+///     final nonNativeTags = usedTags(root).where((x) => !isKnownTag(x));
+///     
+Iterable<String> usedTags(Element element) sync* {
+  yield element.tagName;
   for (Element child in element.childNodes) {
-    yield* nonNativeTags(child);
+    yield* usedTags(child);
   }
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,4 +1,130 @@
 import 'package:charcode/charcode.dart';
+import 'nodes.dart';
+
+/// Defines HTML elements which are not supported by this parser.
+const List<String> unsupportedTags = const [
+  '!DOCTYPE',
+];
+
+/// Defines `void` HTML elements (no closing tag).
+Set<String> voidTags = new Set.from([
+  'area',
+  'base',
+  'basefont',
+  'bgsound',
+  'br',
+  'col',
+  'command',
+  'embed',
+  //'frame', -- is this still a valid HTML5 tag?
+  'hr',
+  'img',
+  'input',
+  'keygen',
+  'link',
+  'meta',
+  'param',
+  'source',
+  'track',
+  'wbr',
+]);
+
+/// Defines normal HTML elements (requires closing tags).
+Set<String> regularTags = new Set.from([
+  'a',
+  'abbr',
+  'address',
+  'article',
+  'aside',
+  'audio',
+  'b',
+  'bdi',
+  'bdo',
+  'blockquote',
+  'body',
+  'button',
+  'canvas',
+  'caption',
+  'cite',
+  'code',
+  'colgroup',
+  'datalist',
+  'dd',
+  'del',
+  'details',
+  'dfn',
+  'dir',
+  'div',
+  'dl',
+  'dt',
+  'em',
+  'fieldset',
+  'figcaption',
+  'figure',
+  'footer',
+  'form',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'head',
+  'header',
+  'hgroup',
+  'html',
+  'i',
+  'iframe',
+  'ins',
+  'kbd',
+  'label',
+  'legend',
+  'li',
+  'map',
+  'mark',
+  'menu',
+  'meter',
+  'nav',
+  'noscript',
+  'object',
+  'ol',
+  'optgroup',
+  'option',
+  'output',
+  'p',
+  'pre',
+  'progress',
+  'q',
+  'rp',
+  'rt',
+  'ruby',
+  's',
+  'samp',
+  'script',
+  'section',
+  'select',
+  'small',
+  'span',
+  'strong',
+  'style',
+  'sub',
+  'summary',
+  'sup',
+  'table',
+  'tbody',
+  'td',
+  'textarea',
+  'tfoot',
+  'th',
+  'thead',
+  'time',
+  'title',
+  'tr',
+  'u',
+  'ul',
+  'var',
+  'video',
+]);
 
 /// Whether [c] is considered a white-space character.
 bool isWhitespace(int c) =>
@@ -9,24 +135,27 @@ bool isWhitespace(int c) =>
     c == $cr /**** '\r' */;
 
 /// Whether [tagName] is a considered a `void` HTML element (no closing tag).
-bool isVoid(String tagName) => const <String>[
-      'area',
-      'base',
-      'basefont',
-      'bgsound',
-      'br',
-      'col',
-      'command',
-      'embed',
-      'frame',
-      'hr',
-      'img',
-      'input',
-      'keygen',
-      'link',
-      'meta',
-      'param',
-      'source',
-      'track',
-      'wbr',
-    ].contains(tagName.toLowerCase());
+bool isVoid(String tagName) => voidTags.contains(tagName.toLowerCase());
+
+/// Whether [tagName] is a know HTML element, or a web/angular component.
+bool isKnownTag(String tagName) {
+  final lowerName = tagName.toLowerCase();
+  return voidTags.contains(lowerName) || regularTags.contains(lowerName);
+}
+
+/// Retrieves all tags which are not known as part of the HTML spec.
+///
+/// This can be used to identify cases where the developer forgot to include
+/// a component in directives.
+/// __example__:
+///     final xs = nonNativeTags(element);
+///     print(xs);
+///     // prints ["my-div", "foo-bar"]
+Iterable<String> nonNativeTags(Element element) sync* {
+  if (!isKnownTag(element.tagName)) {
+    yield element.tagName;
+  }
+  for (Element child in element.childNodes) {
+    yield* nonNativeTags(child);
+  }
+}


### PR DESCRIPTION
Added an initial set of valid html tags, though there might be more.  when combined with a traversal of the produced tree, we can fetch all the tag names which aren't native.  At a later stage, this information could be used to notify the developer if they forgot to include any Components in a Directives field somewhere.
